### PR TITLE
added try catch block to window.performance assignment

### DIFF
--- a/perfnow.src.js
+++ b/perfnow.src.js
@@ -1,5 +1,14 @@
 (function (window) {
-  window.performance = window.performance || {};
+  -- prevent type error on older versions of ff
+  try {
+      window.performance = window.performance || {};
+  }
+  catch(e){
+    if (console && typeof console == "object") {
+       console.log('Warning: '+e.message+' - polyfill::perfnow');
+      
+    }
+  }
   // handle vendor prefixing
   performance.now = performance.now ||
   performance.mozNow ||


### PR DESCRIPTION
prevent the following error:
firefox v21: TypeError:  setting a property that only has a getter
